### PR TITLE
Feat/rate limit interface unit test

### DIFF
--- a/lib/rate-limiter.interface.spec.ts
+++ b/lib/rate-limiter.interface.spec.ts
@@ -1,4 +1,4 @@
-import { RateLimiterOptionsFactory, RateLimiterModuleAsyncOptions } from './rate-limiter.interface'
+import { RateLimiterOptionsFactory, RateLimiterModuleAsyncOptions, RateLimiterOptions } from './rate-limiter.interface'
 
 describe('RateLimiterOptionsFactory', () => {
 	it('should validate that RateLimiterOptionsFactory exists', async () => {
@@ -26,4 +26,28 @@ describe('RateLimiterModuleAsyncOptions', () => {
 		expect(rateLimiterModuleAsyncOptions.useFactory).toBeDefined()
 		expect(rateLimiterModuleAsyncOptions.inject.length).toBe(1)
 	})
-});
+})
+
+describe('RateLimiterOptions', () => {
+	it('should validate that RateLimiterOptions with no properties', async () => {
+		const rateLimiterOptions: RateLimiterOptions = {}
+		expect(rateLimiterOptions).toBeDefined()
+		expect(rateLimiterOptions.for).toBeUndefined()
+    })
+    
+    it('should validate that RateLimiterOptions with no properties', async () => {
+		const rateLimiterOptions: RateLimiterOptions = {
+            for: 'Express',
+            type: 'Memory',
+            points: 2,
+            pointsConsumed: 3,
+            dbName: 'test'
+        }
+		expect(rateLimiterOptions).toBeDefined()
+        expect(rateLimiterOptions.for).toBe('Express')
+        expect(rateLimiterOptions.type).toBe('Memory')
+        expect(rateLimiterOptions.points).toBe(2)
+        expect(rateLimiterOptions.pointsConsumed).toBe(3)
+        expect(rateLimiterOptions.dbName).toBe('test')
+	})
+})

--- a/lib/rate-limiter.interface.spec.ts
+++ b/lib/rate-limiter.interface.spec.ts
@@ -1,0 +1,29 @@
+import { RateLimiterOptionsFactory, RateLimiterModuleAsyncOptions } from './rate-limiter.interface'
+
+describe('RateLimiterOptionsFactory', () => {
+	it('should validate that RateLimiterOptionsFactory exists', async () => {
+		const rateLimiterOptionsFactory: RateLimiterOptionsFactory = {
+			createRateLimiterOptions: jest.fn()
+		}
+		expect(rateLimiterOptionsFactory).toBeDefined()
+		expect(rateLimiterOptionsFactory.createRateLimiterOptions).toBeDefined()
+	})
+})
+
+describe('RateLimiterModuleAsyncOptions', () => {
+	it('should validate that RateLimiterModuleAsyncOptions with no properties', async () => {
+		const rateLimiterModuleAsyncOptions: RateLimiterModuleAsyncOptions = {}
+		expect(rateLimiterModuleAsyncOptions).toBeDefined()
+		expect(rateLimiterModuleAsyncOptions.useExisting).toBeUndefined()
+	})
+
+	it('should validate that RateLimiterModuleAsyncOptions with optional properties', async () => {
+		const rateLimiterModuleAsyncOptions: RateLimiterModuleAsyncOptions = {
+			useFactory: jest.fn(),
+			inject: ['test']
+		}
+		expect(rateLimiterModuleAsyncOptions).toBeDefined()
+		expect(rateLimiterModuleAsyncOptions.useFactory).toBeDefined()
+		expect(rateLimiterModuleAsyncOptions.inject.length).toBe(1)
+	})
+});

--- a/lib/rate-limiter.interface.spec.ts
+++ b/lib/rate-limiter.interface.spec.ts
@@ -33,21 +33,21 @@ describe('RateLimiterOptions', () => {
 		const rateLimiterOptions: RateLimiterOptions = {}
 		expect(rateLimiterOptions).toBeDefined()
 		expect(rateLimiterOptions.for).toBeUndefined()
-    })
-    
-    it('should validate that RateLimiterOptions with no properties', async () => {
+	})
+
+	it('should validate that RateLimiterOptions with no properties', async () => {
 		const rateLimiterOptions: RateLimiterOptions = {
-            for: 'Express',
-            type: 'Memory',
-            points: 2,
-            pointsConsumed: 3,
-            dbName: 'test'
-        }
+			for: 'Express',
+			type: 'Memory',
+			points: 2,
+			pointsConsumed: 3,
+			dbName: 'test'
+		}
 		expect(rateLimiterOptions).toBeDefined()
-        expect(rateLimiterOptions.for).toBe('Express')
-        expect(rateLimiterOptions.type).toBe('Memory')
-        expect(rateLimiterOptions.points).toBe(2)
-        expect(rateLimiterOptions.pointsConsumed).toBe(3)
-        expect(rateLimiterOptions.dbName).toBe('test')
+		expect(rateLimiterOptions.for).toBe('Express')
+		expect(rateLimiterOptions.type).toBe('Memory')
+		expect(rateLimiterOptions.points).toBe(2)
+		expect(rateLimiterOptions.pointsConsumed).toBe(3)
+		expect(rateLimiterOptions.dbName).toBe('test')
 	})
 })


### PR DESCRIPTION
The following is another very simple PR to look at expanding the amount of test coverage.  This is linked to issue #36. This PR really focuses on making sure the interfaces have some simple tests.  Here is a summary of what was added to the PR:

# Changes in PR:
1. Adds a simple spec for the rate-limiter.interface

# Outputs

## Tests
The following is the output of the tests

```
npm run test
```

![Screen Shot 2020-11-22 at 1 51 19 PM](https://user-images.githubusercontent.com/2457835/99914268-2161b700-2cca-11eb-8bef-afa6e890ac4d.png)


## Linting

```
npm run lint
```

![Screen Shot 2020-11-22 at 1 51 36 PM](https://user-images.githubusercontent.com/2457835/99914276-2fafd300-2cca-11eb-9695-4372a8e8fd51.png)


## Build

```
npm run build
```

![Screen Shot 2020-11-22 at 1 55 00 PM](https://user-images.githubusercontent.com/2457835/99914288-553cdc80-2cca-11eb-80e5-fe1f9f3e37c5.png)


