### PR TITLE
Feat/add unit test decorator

### DIFF
--- a/lib/rate-limiter.decorator.spec.ts
+++ b/lib/rate-limiter.decorator.spec.ts
@@ -1,0 +1,32 @@
+import { RateLimit } from './rate-limiter.decorator'
+import { RateLimiterOptions } from './rate-limiter.interface'
+
+describe('RateLimit', () => {
+	it('should validate that RateLimit decorator exists', async () => {
+		expect(RateLimit).toBeDefined()
+	})
+
+	it('should verify RateLimit Method decorator can be created with empty options', async () => {
+		const options: RateLimiterOptions = {}
+
+		const decorator: MethodDecorator = RateLimit(options)
+
+		expect(decorator).toBeDefined()
+	})
+
+	it('should verify RateLimit can decorate a method and be called', async () => {
+		const options: RateLimiterOptions = {}
+		const testFn = jest.fn()
+
+		class TestController {
+			@RateLimit(options)
+			run() {
+				testFn()
+			}
+		}
+
+		const controller = new TestController()
+
+		expect(testFn)
+	})
+})

--- a/lib/rate-limiter.decorator.spec.ts
+++ b/lib/rate-limiter.decorator.spec.ts
@@ -25,8 +25,9 @@ describe('RateLimit', () => {
 			}
 		}
 
-		const controller = new TestController()
+        const controller = new TestController()
+        controller.run()
 
-		expect(testFn)
+		expect(testFn).toHaveBeenCalled()
 	})
 })

--- a/lib/rate-limiter.decorator.spec.ts
+++ b/lib/rate-limiter.decorator.spec.ts
@@ -25,8 +25,8 @@ describe('RateLimit', () => {
 			}
 		}
 
-        const controller = new TestController()
-        controller.run()
+		const controller = new TestController()
+		controller.run()
 
 		expect(testFn).toHaveBeenCalled()
 	})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,5 @@
     ],
     "exclude": [
         "node_modules",
-        "**/*.spec.ts"
     ]
 }


### PR DESCRIPTION
This PR is another simple enhancement to help increase the code coverage across the app (specifically on the decorator function #43).   I discussed with @ozkanonur and he mentioned that he would be open to doing a bit of refactoring and maybe automatically deploying the app when a PR is merged to master.  These tests are all in support of trying to get to this goal.  This PR provides the following:

1. Some basic unit tests for the rate-limiter.decorator.ts file
2. I removed the exclusion for the for the specs as it was causing an issue when trying to test the decorators (i.e. @RateLimit) in the .spec.ts files

```
    "exclude": [
        "node_modules",
         "**/*.spec.ts" -- This was removed to enable (@RateLimit in .spec.ts files)
    ]
```

**Tests Output**
```
npm run test
```

<img width="641" alt="Screen Shot 2020-11-24 at 9 04 20 PM" src="https://user-images.githubusercontent.com/2457835/100173527-b31f1f00-2e98-11eb-87a8-a5f352e9f172.png">

**Lint Output**

```
npm run lint
```

<img width="631" alt="Screen Shot 2020-11-24 at 9 04 34 PM" src="https://user-images.githubusercontent.com/2457835/100173563-c7fbb280-2e98-11eb-932b-777f56544b7b.png">


**Build Output**

```
npm run build
```

<img width="667" alt="Screen Shot 2020-11-24 at 9 04 47 PM" src="https://user-images.githubusercontent.com/2457835/100173571-cf22c080-2e98-11eb-9fb8-60358627411f.png">
