### PR TITLE
Add Jest Code Coverage configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ npm-debug.log
 
 # dist
 /dist
+
+/coverage

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,4 +5,12 @@ module.exports = {
     },
     testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.ts?$',
     moduleFileExtensions: ['ts', 'js', 'jsx', 'json', 'node'],
+    coverageThreshold: {
+      global: {
+          branches: 90,
+          functions: 90,
+          lines: 90,
+          statements: 90,
+      },
+    },
   }

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,6 +5,8 @@ module.exports = {
     },
     testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.ts?$',
     moduleFileExtensions: ['ts', 'js', 'jsx', 'json', 'node'],
+    collectCoverage: true,
+    coverageDirectory: "./coverage",
     coverageThreshold: {
       global: {
           branches: 90,

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "prebuild": "rm -rf dist",
     "build": "tsc -p tsconfig.json",
     "lint": "prettier --write lib",
-    "test": "jest --coverage"
+    "test": "jest --config ./jest.config.js"
   },
   "dependencies": {
     "rate-limiter-flexible": "2.1.10"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "prebuild": "rm -rf dist",
     "build": "tsc -p tsconfig.json",
     "lint": "prettier --write lib",
-    "test": "jest"
+    "test": "jest --coverage"
   },
   "dependencies": {
     "rate-limiter-flexible": "2.1.10"


### PR DESCRIPTION
The following PR is a simple enhancement to ensure that the code coverage for the library stays high as enhancements/features are added (A small fix for #46 ).  The PR includes the following changes:

1. Updated the jest.config.js to include global rules for test coverage

```
coverageThreshold: {
      global: {
          branches: 90,
          functions: 90,
          lines: 90,
          statements: 90,
      },
    },
```
2. Update the package.json script (test) to include the coverage option
3. Update the .gitignore so that the output of coverage is not checked in to github


**Test Output**

```
npm run test
```

<img width="645" alt="Screen Shot 2020-11-24 at 10 44 10 PM" src="https://user-images.githubusercontent.com/2457835/100180793-f5e7f380-2ea6-11eb-85f5-66e96fcf57a0.png">


**Lint Output**

```
npm run lint
```

<img width="648" alt="Screen Shot 2020-11-24 at 10 44 25 PM" src="https://user-images.githubusercontent.com/2457835/100180806-fbddd480-2ea6-11eb-8153-d4993aa3ef17.png">


**Build Output**

```
npm run build
```

<img width="669" alt="Screen Shot 2020-11-24 at 10 44 43 PM" src="https://user-images.githubusercontent.com/2457835/100180815-013b1f00-2ea7-11eb-983d-24a03cd311a8.png">
