### PR TITLE
Feat/example white black list

### DIFF
--- a/examples/apps/rate-limiter-express-app/src/app/app.module.ts
+++ b/examples/apps/rate-limiter-express-app/src/app/app.module.ts
@@ -1,12 +1,12 @@
 import { Module } from '@nestjs/common';
 import { APP_INTERCEPTOR } from '@nestjs/core';
-import { AppController, PointsController } from './controllers';
+import { AppController, PointsController, BlackWhiteController } from './controllers';
 import { AppService } from './services/app.service';
 import { RateLimiterModule, RateLimiterInterceptor } from '../../../../../dist';
 
 @Module({
   imports: [RateLimiterModule],
-  controllers: [AppController, PointsController],
+  controllers: [AppController, PointsController, BlackWhiteController],
   providers: [AppService,
     {
       provide: APP_INTERCEPTOR,

--- a/examples/apps/rate-limiter-express-app/src/app/controllers/blackwhite.controller.ts
+++ b/examples/apps/rate-limiter-express-app/src/app/controllers/blackwhite.controller.ts
@@ -12,14 +12,10 @@ export class BlackWhiteController {
     errorMessage: 'The IP Address has been blocked' })
   @Get('/blocklocal')
   async getBlockLocal() {
-    try{
         // Note the format for incoming localhost will be ::1 and the rate limiter will
         // parse hout the leading //
-      const resp = await this.appService.getData();
-      return resp;
-    }catch(err){
-      throw err;
-    }
+        const resp = await this.appService.getData();
+        return resp;
   }
 
   @RateLimit({
@@ -27,29 +23,21 @@ export class BlackWhiteController {
     errorMessage: 'The IP Address has been blocked' })
   @Get('/blockspecific')
   async getBlockSpecificIP() {
-    try{
       const resp = await this.appService.getData();
       return resp;
-    }catch(err){
-      throw err;
-    }
   }
 
   @RateLimit({
       points: 1,
       duration: 10,
-      whiteList:['1'],
+      whiteList:['1', '127.0.0.1'],
       errorMessage: 'The IP Address is making too many requests' })
   @Get('/enablelocal')
   async getEnableLocalHost() {
       // The following enpoint will restrict all IP addresses to 1 request every
       // 10 seconds, except localhost ```::1``` 
-    try{
       const resp = await this.appService.getData();
       return resp;
-    }catch(err){
-      throw err;
-    }
   }
 
   @RateLimit({
@@ -57,15 +45,12 @@ export class BlackWhiteController {
     duration: 10,
     whiteList:['192.168.0.1','192.168.2.101'],
     errorMessage: 'The IP Address is making too many requests' })
-@Get('/enablelocal')
-async getRestrictLocalHost() {
-    // The following enpoint will restrict all IP addresses to 1 request every
-    // 10 seconds, except the following: ```192.168.0.1,192.168.2.101```
-  try{
-    const resp = await this.appService.getData();
-    return resp;
-  }catch(err){
-    throw err;
+  @Get('/restrictlocal')
+  async getRestrictLocalHost() {
+      // The following enpoint will restrict all IP addresses to 1 request every
+      // 10 seconds, except the following: ```192.168.0.1,192.168.2.101```
+      const resp = await this.appService.getData();
+      return resp;
+
   }
-}
 }

--- a/examples/apps/rate-limiter-express-app/src/app/controllers/blackwhite.controller.ts
+++ b/examples/apps/rate-limiter-express-app/src/app/controllers/blackwhite.controller.ts
@@ -35,7 +35,7 @@ export class BlackWhiteController {
   @Get('/enablelocal')
   async getEnableLocalHost() {
       // The following enpoint will restrict all IP addresses to 1 request every
-      // 10 seconds, except localhost ```::1``` 
+      // 10 seconds, except localhost ```::1```
       const resp = await this.appService.getData();
       return resp;
   }

--- a/examples/apps/rate-limiter-express-app/src/app/controllers/blackwhite.controller.ts
+++ b/examples/apps/rate-limiter-express-app/src/app/controllers/blackwhite.controller.ts
@@ -1,0 +1,71 @@
+import { Controller, Get } from '@nestjs/common';
+
+import { AppService } from '../services/app.service';
+import { RateLimit } from '../../../../../../dist';
+
+@Controller('blackwhite')
+export class BlackWhiteController {
+  constructor(private readonly appService: AppService) {}
+
+  @RateLimit({
+    blackList:['1'],
+    errorMessage: 'The IP Address has been blocked' })
+  @Get('/blocklocal')
+  async getBlockLocal() {
+    try{
+        // Note the format for incoming localhost will be ::1 and the rate limiter will
+        // parse hout the leading //
+      const resp = await this.appService.getData();
+      return resp;
+    }catch(err){
+      throw err;
+    }
+  }
+
+  @RateLimit({
+    blackList:['192.168.0.11', '192.168.2.101'],
+    errorMessage: 'The IP Address has been blocked' })
+  @Get('/blockspecific')
+  async getBlockSpecificIP() {
+    try{
+      const resp = await this.appService.getData();
+      return resp;
+    }catch(err){
+      throw err;
+    }
+  }
+
+  @RateLimit({
+      points: 1,
+      duration: 10,
+      whiteList:['1'],
+      errorMessage: 'The IP Address is making too many requests' })
+  @Get('/enablelocal')
+  async getEnableLocalHost() {
+      // The following enpoint will restrict all IP addresses to 1 request every
+      // 10 seconds, except localhost ```::1``` 
+    try{
+      const resp = await this.appService.getData();
+      return resp;
+    }catch(err){
+      throw err;
+    }
+  }
+
+  @RateLimit({
+    points: 1,
+    duration: 10,
+    whiteList:['192.168.0.1','192.168.2.101'],
+    errorMessage: 'The IP Address is making too many requests' })
+@Get('/enablelocal')
+async getRestrictLocalHost() {
+    // The following enpoint will restrict all IP addresses to 1 request every
+    // 10 seconds, except the following: ```192.168.0.1,192.168.2.101```
+  try{
+    const resp = await this.appService.getData();
+    return resp;
+  }catch(err){
+    throw err;
+  }
+}
+}

--- a/examples/apps/rate-limiter-express-app/src/app/controllers/index.ts
+++ b/examples/apps/rate-limiter-express-app/src/app/controllers/index.ts
@@ -1,2 +1,3 @@
 export { AppController } from './app.controller';
 export { PointsController} from './points.controller';
+export { BlackWhiteController } from './blackwhite.controller';

--- a/examples/apps/rate-limiter-express-app/src/app/controllers/points.controller.ts
+++ b/examples/apps/rate-limiter-express-app/src/app/controllers/points.controller.ts
@@ -13,12 +13,8 @@ export class PointsController {
     errorMessage: 'Accounts cannot be created more than once in per minute' })
   @Get()
   async getPoints() {
-    try{
       const resp = await this.appService.getData();
       return resp;
-    }catch(err){
-      throw err;
-    }
   }
 
   @RateLimit({
@@ -28,11 +24,7 @@ export class PointsController {
     errorMessage: 'Accounts cannot be created more than once in per minute' })
   @Get('/consumed')
   async getPointsConsumed() {
-    try{
       const resp = await this.appService.getData();
       return resp;
-    }catch(err){
-      throw err;
-    }
   }
 }

--- a/examples/apps/rate-limiter-express-app/src/app/services/app.service.ts
+++ b/examples/apps/rate-limiter-express-app/src/app/services/app.service.ts
@@ -3,13 +3,8 @@ import { Injectable } from '@nestjs/common';
 @Injectable()
 export class AppService {
   async getData(): Promise<{ message: string }>  {
-
-    try{
       return new Promise( resolve => {
         return resolve({message:'Welcome to rate-limiter-express-app!'});
       })
-    }catch(err){
-      throw err;
-    }
   }
 }

--- a/examples/apps/rate-limiter-express-test-app/src/main.ts
+++ b/examples/apps/rate-limiter-express-test-app/src/main.ts
@@ -1,11 +1,16 @@
-import { testBelowMaximumPoints, testExceedingMaximumPoints, testBlockLocalhost, testBlockNonLocalhost, testWhiteListLocalhost, testRestrictLocalhost } from '@examples/rate-limiter-points-test';
+import { 
+    testBelowMaximumPoints, 
+    testExceedingMaximumPoints, 
+    testBlockLocalhost, 
+    testBlockNonLocalhost, 
+    testWhiteListLocalhost, 
+    testRestrictLocalhost } from '@examples/rate-limiter-points-test';
 import * as assert from 'assert';
 
 const BASE_URL  = 'http://localhost:3333/api';
 
 const execute = async () => {
     try{
-        console.log( 'Start Running tests');
         assert (await testBelowMaximumPoints(BASE_URL) );
 
         assert (await testExceedingMaximumPoints(BASE_URL) );
@@ -17,7 +22,6 @@ const execute = async () => {
         assert( await testWhiteListLocalhost(BASE_URL));
 
         assert( await testRestrictLocalhost(BASE_URL));
-        console.log( 'End Testss');
         process.exit(1);
     }catch(err){
         process.exit(1);

--- a/examples/apps/rate-limiter-express-test-app/src/main.ts
+++ b/examples/apps/rate-limiter-express-test-app/src/main.ts
@@ -1,14 +1,18 @@
-import { testBelowMaximumPoints, testExceedingMaximumPoints } from '@examples/rate-limiter-points-test';
+import { testBelowMaximumPoints, testExceedingMaximumPoints, testBlockLocalhost } from '@examples/rate-limiter-points-test';
 import * as assert from 'assert';
 
 const BASE_URL  = 'http://localhost:3333/api';
 
 const execute = async () => {
     try{
+
+        console.log( 'Start Running tests');
         assert (await testBelowMaximumPoints(BASE_URL) );
 
 
         assert (await testExceedingMaximumPoints(BASE_URL) );
+
+        // assert ( await testBlockLocalhost(BASE_URL));
         process.exit(1);
     }catch(err){
         process.exit(1);

--- a/examples/apps/rate-limiter-express-test-app/src/main.ts
+++ b/examples/apps/rate-limiter-express-test-app/src/main.ts
@@ -5,22 +5,16 @@ const BASE_URL  = 'http://localhost:3333/api';
 
 const execute = async () => {
     try{
-
         console.log( 'Start Running tests');
         assert (await testBelowMaximumPoints(BASE_URL) );
-        console.log( 'Start Maxiumum Points');
 
         assert (await testExceedingMaximumPoints(BASE_URL) );
 
-
         assert ( await testBlockLocalhost(BASE_URL));
 
-        console.log( 'Start Block Non Local host');
         assert ( await testBlockNonLocalhost(BASE_URL));
 
-        console.log( 'Start Whitelist Local host');
         assert( await testWhiteListLocalhost(BASE_URL));
-
 
         assert( await testRestrictLocalhost(BASE_URL));
         console.log( 'End Testss');

--- a/examples/apps/rate-limiter-express-test-app/src/main.ts
+++ b/examples/apps/rate-limiter-express-test-app/src/main.ts
@@ -1,9 +1,9 @@
-import { 
-    testBelowMaximumPoints, 
-    testExceedingMaximumPoints, 
-    testBlockLocalhost, 
-    testBlockNonLocalhost, 
-    testWhiteListLocalhost, 
+import {
+    testBelowMaximumPoints,
+    testExceedingMaximumPoints,
+    testBlockLocalhost,
+    testBlockNonLocalhost,
+    testWhiteListLocalhost,
     testRestrictLocalhost } from '@examples/rate-limiter-points-test';
 import * as assert from 'assert';
 

--- a/examples/apps/rate-limiter-express-test-app/src/main.ts
+++ b/examples/apps/rate-limiter-express-test-app/src/main.ts
@@ -1,4 +1,4 @@
-import { testBelowMaximumPoints, testExceedingMaximumPoints, testBlockLocalhost } from '@examples/rate-limiter-points-test';
+import { testBelowMaximumPoints, testExceedingMaximumPoints, testBlockLocalhost, testBlockNonLocalhost, testWhiteListLocalhost, testRestrictLocalhost } from '@examples/rate-limiter-points-test';
 import * as assert from 'assert';
 
 const BASE_URL  = 'http://localhost:3333/api';
@@ -8,11 +8,22 @@ const execute = async () => {
 
         console.log( 'Start Running tests');
         assert (await testBelowMaximumPoints(BASE_URL) );
-
+        console.log( 'Start Maxiumum Points');
 
         assert (await testExceedingMaximumPoints(BASE_URL) );
 
-        // assert ( await testBlockLocalhost(BASE_URL));
+
+        assert ( await testBlockLocalhost(BASE_URL));
+
+        console.log( 'Start Block Non Local host');
+        assert ( await testBlockNonLocalhost(BASE_URL));
+
+        console.log( 'Start Whitelist Local host');
+        assert( await testWhiteListLocalhost(BASE_URL));
+
+
+        assert( await testRestrictLocalhost(BASE_URL));
+        console.log( 'End Testss');
         process.exit(1);
     }catch(err){
         process.exit(1);

--- a/examples/libs/loadtest-common/src/index.ts
+++ b/examples/libs/loadtest-common/src/index.ts
@@ -1,2 +1,2 @@
-export { runLoadTest } from './lib/loadtest-common';
 export { LoadTestResponse, LoadTestOptions } from './lib/loadtest-model';
+export { runLoadTest } from './lib/loadtest-common';

--- a/examples/libs/loadtest-common/src/lib/loadtest-model.ts
+++ b/examples/libs/loadtest-common/src/lib/loadtest-model.ts
@@ -16,4 +16,5 @@ export interface LoadTestOptions {
     maxRequests: number;
     maxSeconds: number;
     timeout: number;
+    concurrency?: number;
 }

--- a/examples/libs/rate-limiter-points-test/src/index.ts
+++ b/examples/libs/rate-limiter-points-test/src/index.ts
@@ -1,2 +1,2 @@
 export { testBelowMaximumPoints, testExceedingMaximumPoints } from './lib/rate-limiter-points-test';
-export { testBlockLocalhost } from './lib/rate-limiter-blackwhite-test';
+export { testBlockLocalhost, testBlockNonLocalhost, testWhiteListLocalhost, testRestrictLocalhost } from './lib/rate-limiter-blackwhite-test';

--- a/examples/libs/rate-limiter-points-test/src/index.ts
+++ b/examples/libs/rate-limiter-points-test/src/index.ts
@@ -1,1 +1,2 @@
 export { testBelowMaximumPoints, testExceedingMaximumPoints } from './lib/rate-limiter-points-test';
+export { testBlockLocalhost } from './lib/rate-limiter-blackwhite-test';

--- a/examples/libs/rate-limiter-points-test/src/lib/rate-limiter-blackwhite-test.ts
+++ b/examples/libs/rate-limiter-points-test/src/lib/rate-limiter-blackwhite-test.ts
@@ -11,13 +11,9 @@ export const testBlockLocalhost = async ( url: string): Promise<boolean> => {
     concurrency:3
   };
   try{
-    const response  = await runLoadTest( options );
+    const response: LoadTestResponse  = await runLoadTest( options );
 
-    console.log('Response', response);
-    // All incoming requests should be blocked
-    //return (response.totalRequests === 5 && response.totalErrors === 5 );
-
-    return true;
+    return (response.totalRequests === 5 && response.totalErrors === 5 );
   }catch( err ){
     // tslint:disable-next-line: no-console
     console.log( `Unexpected error testing points consumed ${err}`)
@@ -25,3 +21,59 @@ export const testBlockLocalhost = async ( url: string): Promise<boolean> => {
   }
 }
 
+export const testBlockNonLocalhost = async ( url: string): Promise<boolean> => {
+  const options: LoadTestOptions  = {
+    url: `${url}${BLACK_WHITE_ROUTE}/blockspecific`,
+    maxRequests: 5,
+    maxSeconds: 2,
+    timeout: 300,
+    concurrency:3
+  };
+  try{
+    const response: LoadTestResponse  = await runLoadTest( options );
+
+    return (response.totalRequests === 5 );
+  }catch( err ){
+    // tslint:disable-next-line: no-console
+    console.log( `Unexpected error testing points consumed ${err}`)
+    return false;
+  }
+}
+
+export const testWhiteListLocalhost = async ( url: string): Promise<boolean> => {
+  const options: LoadTestOptions  = {
+    url: `${url}${BLACK_WHITE_ROUTE}/enablelocal`,
+    maxRequests: 5,
+    maxSeconds: 2,
+    timeout: 300,
+    concurrency:3
+  };
+  try{
+    const response: LoadTestResponse  = await runLoadTest( options );
+
+    return (response.totalRequests === 5 && response.totalErrors === 0 );
+  }catch( err ){
+    // tslint:disable-next-line: no-console
+    console.log( `Unexpected error testing points consumed ${err}`)
+    return false;
+  }
+}
+
+export const testRestrictLocalhost = async ( url: string): Promise<boolean> => {
+  const options: LoadTestOptions  = {
+    url: `${url}${BLACK_WHITE_ROUTE}/restrictlocal`,
+    maxRequests: 5,
+    maxSeconds: 2,
+    timeout: 300,
+    concurrency:3
+  };
+  try{
+    const response: LoadTestResponse  = await runLoadTest( options );
+
+    return (response.totalRequests === 5);
+  }catch( err ){
+    // tslint:disable-next-line: no-console
+    console.log( `Unexpected error testing points consumed ${err}`)
+    return false;
+  }
+}

--- a/examples/libs/rate-limiter-points-test/src/lib/rate-limiter-blackwhite-test.ts
+++ b/examples/libs/rate-limiter-points-test/src/lib/rate-limiter-blackwhite-test.ts
@@ -11,11 +11,13 @@ export const testBlockLocalhost = async ( url: string): Promise<boolean> => {
     concurrency:3
   };
   try{
-    const response: LoadTestResponse = await runLoadTest( options );
+    const response  = await runLoadTest( options );
 
-    console.log( 'Response for Blocked', response);
+    console.log('Response', response);
+    // All incoming requests should be blocked
+    //return (response.totalRequests === 5 && response.totalErrors === 5 );
 
-    return (response.totalRequests === 2 && response.totalErrors === 0 );
+    return true;
   }catch( err ){
     // tslint:disable-next-line: no-console
     console.log( `Unexpected error testing points consumed ${err}`)

--- a/examples/libs/rate-limiter-points-test/src/lib/rate-limiter-blackwhite-test.ts
+++ b/examples/libs/rate-limiter-points-test/src/lib/rate-limiter-blackwhite-test.ts
@@ -1,0 +1,25 @@
+import { runLoadTest, LoadTestResponse, LoadTestOptions} from '@examples/loadtest-common';
+
+const BLACK_WHITE_ROUTE = '/blackwhite';
+
+export const testBlockLocalhost = async ( url: string): Promise<boolean> => {
+  const options: LoadTestOptions  = {
+    url: `${url}${BLACK_WHITE_ROUTE}/blocklocal`,
+    maxRequests: 5,
+    maxSeconds: 2,
+    timeout: 300,
+    concurrency:3
+  };
+  try{
+    const response: LoadTestResponse = await runLoadTest( options );
+
+    console.log( 'Response for Blocked', response);
+
+    return (response.totalRequests === 2 && response.totalErrors === 0 );
+  }catch( err ){
+    // tslint:disable-next-line: no-console
+    console.log( `Unexpected error testing points consumed ${err}`)
+    return false;
+  }
+}
+


### PR DESCRIPTION
The following PR is in response to issue (#53) which is to expand the number of samples.  This PR is specifically related to illustrating how to use black and white listing.  This PR includes the following changes:

1. A sample controller for to show how to configure white and black listing
2. A sample test file that provides the following tests:
i. Testing a blocked IP Address (i.e. localhost ::1)
ii. Testing a non blocked IP Address (i.e. something other than local host)
iii. Testing White Listing
iv. Testing restricting with an IP Address (i.e. localhost)

The following is a summary of the changes

```
examples/apps/rate-limiter-express-app/src/app/conterollers/blackwhite.controller.ts
```

This controller has 4 endpoints to illustrate how to use both black and white listing


```
examples/libs/rate-limiter-points-test/src/lib/rate-limiter-blackwhite-test.ts
```
This library is used to configure loadtest to send the appropriate calls to the black and white controller to test the different scenarios.

```
examples/apps/rate-limiter-express-test-app/src/app/main.ts
```
This is the main executable which will run the tests