### PR TITLE
Adding getIpFromRequest method to get the request's IP

### DIFF
--- a/lib/rate-limiter.guard.ts
+++ b/lib/rate-limiter.guard.ts
@@ -171,7 +171,7 @@ export class RateLimiterGuard implements CanActivate {
 		await this.responseHandler(response, key, rateLimiter, points, pointsConsumed)
 		return true
 	}
-	
+
 	protected getIpFromRequest(request: { ip: string }): string {
 	        return request.ip?.match(/\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b/)?.[0]
 	}

--- a/lib/rate-limiter.guard.ts
+++ b/lib/rate-limiter.guard.ts
@@ -166,10 +166,14 @@ export class RateLimiterGuard implements CanActivate {
 		const response = this.httpHandler(context).res
 
 		const rateLimiter: RateLimiterAbstract = await this.getRateLimiter(reflectedOptions)
-		const key = request.ip?.match(/\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b/)?.[0]
+		const key = this.getIpFromRequest(request)
 
 		await this.responseHandler(response, key, rateLimiter, points, pointsConsumed)
 		return true
+	}
+	
+	protected getIpFromRequest(request: { ip: string }): string {
+	        return request.ip?.match(/\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b/)?.[0]
 	}
 
 	private httpHandler(context: ExecutionContext) {


### PR DESCRIPTION
Our project sits behind the proxy, so we need to get IP from the headers (`x-forwarded-for`).

If necessary, a developer could extend `RateLimiterGuard` class and override the `getIpFromRequest` method:

```typescript
import { RateLimiterGuard } from 'nestjs-rate-limiter'
import type { Request } from 'express'

class MyRateLimiterGuard extends RateLimiterGuard {
  protected getIpFromRequest(request: Request): string {
    return request.get('x-forwarded-for');
  }
}
```

This would also help to solve the problem mentioned [here](https://github.com/ozkanonur/nestjs-rate-limiter/pull/83#issuecomment-962421335):

```typescript
import { RateLimiterGuard } from 'nestjs-rate-limiter'
import type { Request } from 'express'
import * as requestIp from 'request-ip'

class MyRateLimiterGuard extends RateLimiterGuard {
  protected getIpFromRequest(request: Request): string {
    return requestIp.getClientIp(request);
  }
}
```